### PR TITLE
Clarify board width/height

### DIFF
--- a/references/api.md
+++ b/references/api.md
@@ -498,8 +498,8 @@ The game board is represented by a standard 2D grid, oriented with \(0,0\) in th
 {% code title="example-board-object.json" %}
 ```javascript
 {
-  "height": 11,
-  "width": 11,
+  "height": 12,
+  "width": 12,
   "food": [
     {"x": 5, "y": 5}, 
     {"x": 9, "y": 0}, 
@@ -537,7 +537,7 @@ The game board is represented by a standard 2D grid, oriented with \(0,0\) in th
       <td style="text-align:left">integer</td>
       <td style="text-align:left">
         <p>Height of the game board.</p>
-        <p><em>Example: 11</em>
+        <p><em>Example: 12</em>
         </p>
       </td>
     </tr>
@@ -547,7 +547,7 @@ The game board is represented by a standard 2D grid, oriented with \(0,0\) in th
       <td style="text-align:left">integer</td>
       <td style="text-align:left">
         <p>Width of the game board.</p>
-        <p><em>Example: 11</em>
+        <p><em>Example: 12</em>
         </p>
       </td>
     </tr>


### PR DESCRIPTION
The example JSON can cause confusion since the JSON describe a game board with width/height of 11, but it's right under an example image of a board with a width/height of 12. This could lead developers to believe that the API returns a width/height that's off-by-one than it actually is (Totally didn't just happen to me :P). 

This change updates the example JSON to match what's being shown in the board image.