### PR TITLE
Link pointing to a 404 page

### DIFF
--- a/references/api.md
+++ b/references/api.md
@@ -8,7 +8,7 @@ description: Official Reference for the Battlesnake API (Version 1)
 
 The Battlesnake API is an inverted HTTP API. Developers build a web server that implements this API and the game engine will act as an API client during each game. How your server responds to these requests controls how your Battlesnake behaves.
 
-Requests sent to your Battlesnake will be [JSON-encoded](https://github.com/BattlesnakeOfficial/docs/tree/a2b51f832051788f2b13982fefcf2c74e0cf9db0/references/www.json.org), using standard HTTP request methods and content types.
+Requests sent to your Battlesnake will be [JSON-encoded](https://www.json.org/), using standard HTTP request methods and content types.
 
 ### HTTP Response Codes
 


### PR DESCRIPTION
The link with the text _JSON-encoded_ was pointing to https://github.com/BattlesnakeOfficial/docs/blob/a2b51f832051788f2b13982fefcf2c74e0cf9db0/references/www.json.org which is an invalid endpoint. 

I assume it's supposed to send the user to  https://www.json.org/ instead.

![image](https://user-images.githubusercontent.com/28541538/106909956-0e735600-6701-11eb-837f-fc146d4205ae.png)
